### PR TITLE
Rename workflow-tips.md to Troubleshooting.md

### DIFF
--- a/docs/content-types/create/Troubleshooting.md
+++ b/docs/content-types/create/Troubleshooting.md
@@ -1,9 +1,9 @@
-# Workflow tips
+# Troubleshooting
 
-## Save page
+## Change in the master.html is not visible
 
 When you are working on a page and changing the master.html template, you need to Save the page in the Admin UI and make some kind of change to the preview template on the Admin UI. Otherwise, you will not see your changes in the browser. This is due to how Page Builder updates changes: it will not update the master template until changes have been made to the page.
 
-## Setup and cache
+## Change in the configuration is not visible
 
 If you change something in the configuration of your extension, and the change is not visible, run `bin/magento cache:clean` to ensure that the configuration is updated.


### PR DESCRIPTION
## Description
This is not "tips", this is Troubleshooting.
This is not helping you on the creation of content types to do it faster or easier like real tips because if you don't do this your content type modification doesn't work !
It's troubleshooting. When your change doesn't work you go to the documentation and search the documentation page of the thing you are working on, or the troubleshooting.  
You don't go on 'Tips' page