### PR TITLE
removed develop branch from testing

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - master
-      - develop
     paths:
       - docs/**
 


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description

This PR removes the develop branch from the GitHub actions markdown linting test as there is no longer a develop branch in this repo.
