### PR TITLE
Render tag causing the error in preview.html was moved to the end of the children.

### DIFF
--- a/docs/content-types/create/add-styles.md
+++ b/docs/content-types/create/add-styles.md
@@ -123,10 +123,10 @@ The `class` attributes reference these styles in both our Admin preview template
 ```html
 <!--preview.html-->
 <div attr="data.main.attributes" ko-style="data.main.style" class="pagebuilder-content-type" css="data.main.css" event="{ mouseover: onMouseOver, mouseout: onMouseOut }, mouseoverBubble: false">
-    <render args="getOptions().template" />
     <blockquote class="quote-content" css="data.quote.css" attr="data.quote.attributes" ko-style="data.quote.style" data-bind="liveEdit: { field: 'quote_text', placeholder: $t('Enter Quote') }"></blockquote>
     <div class="quote-author" attr="data.author.attributes" ko-style="data.author.style" data-bind="liveEdit: { field: 'quote_author', placeholder: $t('Enter Author') }"></div>
     <div class="quote-description" attr="data.author_title.attributes" ko-style="data.author_title.style" data-bind="liveEdit: { field: 'quote_author_desc', placeholder: $t('Enter Description') }"></div>
+    <render args="getOptions().template" />
 </div>
 ```
 

--- a/docs/content-types/create/add-templates.md
+++ b/docs/content-types/create/add-templates.md
@@ -74,7 +74,6 @@ The Quote `preview_template`  (`preview.html`) is shown here in full, followed b
      class="pagebuilder-content-type"
      css="data.main.css"
      event="{ mouseover: onMouseOver, mouseout: onMouseOut }, mouseoverBubble: false">
-    <render args="getOptions().template" />
     <blockquote attr="data.quote.attributes"
               ko-style="data.quote.style"
               css="data.quote.css"
@@ -92,6 +91,7 @@ The Quote `preview_template`  (`preview.html`) is shown here in full, followed b
        css="data.author_title.css"
        data-bind="liveEdit: { field: 'quote_author_desc', placeholder: $t('Enter Description') }">
     </div>
+    <render args="getOptions().template" />
 </div>
 ```
 


### PR DESCRIPTION
<!-- Summarize your changes in the Title field -->

## Description
I followed the instructions in the [Content Types Create](https://devdocs.magento.com/page-builder/docs/content-types/create/introduction.html) documentation and created the my first page builder component. But i don't see any visual templates in the page builder area when i was drag and drop my new component. Then i look at the browser console and i saw warning in the picture. Then i moved the render tag, which is the first child tag, to the end of the children and the problem was solved for me.
#56 

## How and where has this been tested?
 - **How this was tested:** <!-- Using steps in issue #000 -->
 - **Browser(s) and OS(s) this was tested with:** <!-- Chrome 104.0.5112.79 on Ubuntu 16.04 -->

## Screenshots
![image](https://user-images.githubusercontent.com/10761479/191990179-99b0af0f-1aff-4d8e-bd62-125a8e9cc07b.png)


## To-do list
<!-- Put an "x" to indicate you've done each of the following -->
- [x] If my change impacts other components, I have tested to make sure they don't break.
- [x] If my change impacts documentation, I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](/.github/CONTRIBUTING.md).
<!-- If this pull request isn't ready, add any remaining tasks here -->
- [x] This pull request is ready to merge.
